### PR TITLE
Visualisation

### DIFF
--- a/insurancesimulation.py
+++ b/insurancesimulation.py
@@ -210,6 +210,10 @@ class InsuranceSimulation():
 
         self.history_logs['market_premium'] = []
         self.history_logs['market_diffvar'] = []
+        
+        # lists to contain agent-level data
+        self.history_logs['insurance_firms_cash'] = []
+        self.history_logs['reinsurance_firms_cash'] = []
 
             
     
@@ -340,6 +344,13 @@ class InsuranceSimulation():
         operational_no = sum([insurancefirm.operational for insurancefirm in self.insurancefirms])
         reinoperational_no = sum([reinsurancefirm.operational for reinsurancefirm in self.reinsurancefirms])
         catbondsoperational_no = sum([catbond.operational for catbond in self.catbonds])
+        
+        # agent-level data
+        
+        insurance_firms = [(insurancefirm.cash,insurancefirm.id) for insurancefirm in self.insurancefirms]
+        reinsurance_firms = [(reinsurancefirm.cash,reinsurancefirm.id) for reinsurancefirm in self.reinsurancefirms]
+        
+        
         self.history_logs['total_cash'].append(total_cash_no)
         self.history_logs['total_excess_capital'].append(total_excess_capital)
         self.history_logs['total_profitslosses'].append(total_profitslosses)
@@ -354,6 +365,10 @@ class InsuranceSimulation():
         self.history_logs['market_premium'].append(self.market_premium)
         self.history_logs['cumulative_bankruptcies'].append(self.cumulative_bankruptcies)
         self.history_logs['cumulative_unrecovered_claims'].append(self.cumulative_unrecovered_claims)
+        
+        # agent-level data
+        self.history_logs['insurance_firms_cash'].append(insurance_firms)
+        self.history_logs['reinsurance_firms_cash'].append(reinsurance_firms)
         self.log_vars()
         
         individual_contracts_no = [len(insurancefirm.underwritten_contracts) for insurancefirm in self.insurancefirms]
@@ -612,30 +627,15 @@ class InsuranceSimulation():
         to_log.append(("data/" + fpf + "_diffvar.dat", self.history_logs['market_diffvar'], "a"))
         to_log.append(("data/" + fpf + "_cumulative_bankruptcies.dat", self.history_logs['cumulative_bankruptcies'], "a"))
         to_log.append(("data/" + fpf + "_cumulative_unrecovered_claims.dat", self.history_logs['cumulative_unrecovered_claims'], "a"))
-
+        
+        # agent-level data
+        to_log.append(("data/" + fpf + "_insurance_firms_cash.dat", self.history_logs['insurance_firms_cash'], "a"))
+        to_log.append(("data/" + fpf + "_reinsurance_firms_cash.dat", self.history_logs['reinsurance_firms_cash'], "a"))
         return to_log
 
     def replication_log_prepare_oneriskmodel(self):
         return self.replication_log_prepare()
         assert False, "Error: script should never reach this point"
-        
-        to_log = []
-        to_log.append(("data/one_operational.dat", self.history_logs['total_operational'], "a"))
-        to_log.append(("data/one_contracts.dat", self.history_logs['total_contracts'], "a"))
-        to_log.append(("data/one_cash.dat", self.history_logs['total_cash'], "a"))
-        to_log.append(("data/one_excess_capital.dat", self.history_logs['total_excess_capital'], "a"))
-        to_log.append(("data/one_profitslosses.dat", self.history_logs['total_profitslosses'], "a"))
-        to_log.append(("data/one_reinoperational.dat", self.history_logs['total_reinoperational'], "a"))
-        to_log.append(("data/one_reincontracts.dat", self.history_logs['total_reincontracts'], "a"))
-        to_log.append(("data/one_reincash.dat", self.history_logs['total_reincash'], "a"))
-        to_log.append(("data/one_reinexcess_capital.dat", self.history_logs['total_reinexcess_capital'], "a"))
-        to_log.append(("data/one_reinprofitslosses.dat", self.history_logs['total_reinprofitslosses'], "a"))
-        to_log.append(("data/catbonds_number.dat", self.history_logs['total_catbondsoperational'], "a"))
-        to_log.append(("data/one_premium.dat", self.history_logs['market_premium'], "a"))
-        to_log.append(("data/one_diffvar.dat", self.history_logs['market_diffvar'], "a"))
-        to_log.append(("data/one_cumulative_bankruptcies.dat", self.history_logs['cumulative_bankruptcies'], "a"))
-        to_log.append(("data/one_cumulative_unrecovered_claims.dat", self.history_logs['cumulative_unrecovered_claims'], "a"))
-
         return to_log
 
     def single_log_prepare(self):
@@ -656,6 +656,10 @@ class InsuranceSimulation():
         to_log.append(("data/cumulative_bankruptcies.dat", self.history_logs['cumulative_bankruptcies'], "w"))
         to_log.append(("data/cumulative_unrecovered_claims.dat", self.history_logs['cumulative_unrecovered_claims'], "w"))
 
+        # agent-level data
+        to_log.append(("data/insurance_firms_cash.dat", self.history_logs['insurance_firms_cash'], "w"))
+        to_log.append(("data/reinsurance_firms_cash.dat", self.history_logs['reinsurance_firms_cash'], "w"))
+        
         return to_log
 
     def log_vars(self):

--- a/starter_two.sh
+++ b/starter_two.sh
@@ -8,7 +8,7 @@ mv data/two_reincontracts.dat data/two_reincontracts.dat_$(date +%Y_%h_%d_%H_%M)
 mv data/two_reincash.dat data/two_reincash.dat_$(date +%Y_%h_%d_%H_%M)
 mv data/two_premium.dat data/two_premium.dat_$(date +%Y_%h_%d_%H_%M)
 
-for ((i=0; i<2; i++)) do
+for ((i=0; i<300; i++)) do
     #python insurancesimulation.py $i
     python start.py --abce 0 --replicid $i 
 done

--- a/starter_two.sh
+++ b/starter_two.sh
@@ -8,7 +8,7 @@ mv data/two_reincontracts.dat data/two_reincontracts.dat_$(date +%Y_%h_%d_%H_%M)
 mv data/two_reincash.dat data/two_reincash.dat_$(date +%Y_%h_%d_%H_%M)
 mv data/two_premium.dat data/two_premium.dat_$(date +%Y_%h_%d_%H_%M)
 
-for ((i=0; i<300; i++)) do
+for ((i=0; i<2; i++)) do
     #python insurancesimulation.py $i
     python start.py --abce 0 --replicid $i 
 done

--- a/visualisation.py
+++ b/visualisation.py
@@ -1,0 +1,67 @@
+# file to visualise agent-level data per timestep
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.animation as animation
+# read in data for each agent for each timestep
+
+# read in insurancefirm data
+rfile = open("data/two_insurance_firms_cash.dat","r")
+insurance_firms_cash = [eval(k) for k in rfile]
+rfile.close()
+# read in reinsurancefirm data
+rfile = open("data/two_reinsurance_firms_cash.dat","r")
+reinsurance_firms_cash = [eval(k) for k in rfile]
+rfile.close()
+
+insurance_firms_cash = np.array(insurance_firms_cash)
+reinsurance_firms_cash = np.array(reinsurance_firms_cash)
+
+# shape (runs, steps)
+print(insurance_firms_cash.shape)
+print(reinsurance_firms_cash.shape)
+
+# let's look at only the first run
+first_run_insurance = insurance_firms_cash[0][:]
+first_run_reinsurance = reinsurance_firms_cash[0][:]
+
+class InsuranceFirmAnimation(object):
+    def __init__(self, data):
+        self.data = data
+        self.fig, self.ax = plt.subplots()
+        self.stream = self.data_stream()
+        self.ani = animation.FuncAnimation(self.fig, self.update, interval=40,
+                                           init_func=self.setup_plot)
+
+    def setup_plot(self):
+        """Initial drawing of the scatter plot."""
+        casharr,idarr = next(self.stream)
+
+        self.pie = self.ax.pie(casharr, labels=idarr)
+
+        return self.pie,
+
+    def data_stream(self):
+        for timestep in self.data:
+            casharr = []
+            idarr = []
+            for (cash, id) in timestep:
+                casharr.append(cash)
+                idarr.append(id)
+            yield casharr,idarr
+
+    def update(self, i):
+        self.ax.clear()
+        self.ax.axis('equal')
+        casharr,idarr = next(self.stream)
+        self.pie = self.ax.pie(casharr, labels=idarr)
+        self.ax.set_title("Timestep : " + str(i))
+        return self.pie,
+
+    def save(self):
+        self.ani.save('line.mp4', writer='ffmpeg', dpi=80)
+
+    def show(self):
+        plt.show()
+        
+anim = InsuranceFirmAnimation(first_run_reinsurance)
+anim.show()


### PR DESCRIPTION
Modified insurancesimulation.py to also save data on agents per timestep
Created file visualisation.py to visualise the new agent data
    visualisation.py very simply compares the size of each reinsurancefirm to one another per timestep
    more complex visualisations can be made from the basic class setup